### PR TITLE
Add governance state utils and observability

### DIFF
--- a/.instructions/TASKS.md
+++ b/.instructions/TASKS.md
@@ -55,6 +55,8 @@
 - Create governance action permission guards — in progress: vote/execute operations run wallet, backend chain capability, action-level plugin capability, indexing readiness and lifecycle checks before wallet submission
 - Add governance nuclei model — in progress: chain registry and frontend fallback distinguish Constitutional Governance powered by `$Neurons` from Local Governance controlled by federated entities
 - Add Constitutional Guardrail reason codes — in progress: backend registry/indexer status and frontend permission guards expose transparent guardrail codes across UI/API flows
+- Add governance standing model — in progress: frontend registry normalization maps legacy constitutional compatibility payloads into constitutional standing, governance status, federation tier and reason severity for rendering only
+- Evolve Governance Operations Center — in progress: `/governance/console` is positioned as a federation observability surface, not a narrow DAO admin page
 
 ---
 

--- a/src/modules/governance/api/chainRegistry.js
+++ b/src/modules/governance/api/chainRegistry.js
@@ -1,3 +1,10 @@
+import {
+  COMPLIANT_CONSTITUTIONAL_STANDING,
+  getConstitutionalStanding,
+  governanceStatusFromStanding,
+  normalizeReasonSeverity,
+} from '../utils/governanceState';
+
 const governanceApiBase = import.meta.env.VITE_GOVERNANCE_API_URL || '/governance-api';
 const registryEndpoint = `${governanceApiBase}/registry/chains`;
 
@@ -13,27 +20,10 @@ const evmPluginTypes = [
 ];
 
 const compatible = { status: 'compatible', reasonCodes: [] };
-const compliantStanding = { status: 'compliant', reasonCodes: [], reasonSeverity: null };
-
-function mapCompatibilityToStanding(value) {
-  if (!value) return compliantStanding;
-  if (value.status === 'compatible') return { ...value, status: 'compliant', reasonSeverity: value.reasonSeverity ?? null };
-  if (value.status === 'requires-review') return { ...value, status: 'under-review', reasonSeverity: value.reasonSeverity ?? 'constitutional' };
-  if (value.status === 'incompatible') return { ...value, status: 'restricted', reasonSeverity: value.reasonSeverity ?? 'critical' };
-  return { ...value, reasonSeverity: value.reasonSeverity ?? null };
-}
-
-function governanceStatusFromStanding(standing) {
-  if (standing?.status === 'under-review') return 'under-review';
-  if (standing?.status === 'restricted') return 'restricted';
-  if (standing?.status === 'sanctioned') return 'sanctioned';
-  if (standing?.status === 'suspended') return 'suspended';
-  return 'compliant';
-}
 
 function normalizePluginCapability(capability) {
   if (!capability) return capability;
-  const constitutionalStanding = mapCompatibilityToStanding(capability.constitutionalStanding ?? capability.constitutionalCompatibility);
+  const constitutionalStanding = getConstitutionalStanding(capability);
   return {
     ...capability,
     governanceStatus: capability.governanceStatus ?? governanceStatusFromStanding(constitutionalStanding),
@@ -50,8 +40,10 @@ function normalizePluginCapabilities(pluginCapabilities) {
 
 export function normalizeChainGovernanceState(chain) {
   const capabilities = chain.capabilities ?? {};
-  const constitutionalStanding = mapCompatibilityToStanding(
-    capabilities.constitutionalStanding ?? chain.constitutionalStanding ?? capabilities.constitutionalCompatibility ?? chain.constitutionalCompatibility,
+  const constitutionalStanding = getConstitutionalStanding(
+    capabilities.constitutionalStanding || capabilities.constitutionalCompatibility || chain.constitutionalStanding || chain.constitutionalCompatibility
+      ? { ...chain, ...capabilities }
+      : null,
   );
   const governanceStatus = chain.governanceStatus ?? capabilities.governanceStatus ?? governanceStatusFromStanding(constitutionalStanding);
 
@@ -70,7 +62,7 @@ export function normalizeChainGovernanceState(chain) {
     indexingStatus: chain.indexingStatus
       ? {
           ...chain.indexingStatus,
-          reasonSeverity: chain.indexingStatus.reasonSeverity ?? (chain.indexingStatus.reasonCode ? 'warning' : null),
+          reasonSeverity: normalizeReasonSeverity(chain.indexingStatus.reasonCode, chain.indexingStatus.reasonSeverity),
         }
       : chain.indexingStatus,
   };
@@ -108,7 +100,7 @@ const pluginCapability = ({ pluginType, label, adapter, vote = true, execute = t
   votingPowerStrategy: strategy,
   compatibleRoles: legacy ? ['voting', 'spoke'] : ['execution', 'voting', 'spoke'],
   constitutionalCompatibility: compatible,
-  constitutionalStanding: compliantStanding,
+  constitutionalStanding: COMPLIANT_CONSTITUTIONAL_STANDING,
   requiresDeployment: true,
   requiresIndexer: true,
   legacy,
@@ -231,7 +223,7 @@ const fallbackChains = [
       constitutionalConditions: true,
       governanceNuclei: ['constitutional', 'local'],
       constitutionalCompatibility: compatible,
-      constitutionalStanding: compliantStanding,
+      constitutionalStanding: COMPLIANT_CONSTITUTIONAL_STANDING,
       governanceStatus: 'compliant',
       localGovernanceModels: evmLocalGovernanceModels,
       supportedPluginTypes: evmPluginTypes,
@@ -263,7 +255,7 @@ const fallbackChains = [
       constitutionalConditions: true,
       governanceNuclei: ['constitutional', 'local'],
       constitutionalCompatibility: compatible,
-      constitutionalStanding: compliantStanding,
+      constitutionalStanding: COMPLIANT_CONSTITUTIONAL_STANDING,
       governanceStatus: 'compliant',
       localGovernanceModels: evmLocalGovernanceModels,
       supportedPluginTypes: evmPluginTypes,
@@ -295,7 +287,7 @@ const fallbackChains = [
       constitutionalConditions: true,
       governanceNuclei: ['constitutional', 'local'],
       constitutionalCompatibility: compatible,
-      constitutionalStanding: compliantStanding,
+      constitutionalStanding: COMPLIANT_CONSTITUTIONAL_STANDING,
       governanceStatus: 'compliant',
       localGovernanceModels: evmLocalGovernanceModels,
       supportedPluginTypes: evmPluginTypes,
@@ -327,7 +319,7 @@ const fallbackChains = [
       constitutionalConditions: true,
       governanceNuclei: ['constitutional', 'local'],
       constitutionalCompatibility: compatible,
-      constitutionalStanding: compliantStanding,
+      constitutionalStanding: COMPLIANT_CONSTITUTIONAL_STANDING,
       governanceStatus: 'compliant',
       localGovernanceModels: evmLocalGovernanceModels,
       supportedPluginTypes: evmPluginTypes,
@@ -359,7 +351,7 @@ const fallbackChains = [
       constitutionalConditions: true,
       governanceNuclei: ['constitutional', 'local'],
       constitutionalCompatibility: compatible,
-      constitutionalStanding: compliantStanding,
+      constitutionalStanding: COMPLIANT_CONSTITUTIONAL_STANDING,
       governanceStatus: 'compliant',
       localGovernanceModels: evmLocalGovernanceModels,
       supportedPluginTypes: evmPluginTypes,
@@ -444,6 +436,22 @@ export function summarizeChainRegistry(chains) {
   const evmCount = chains.filter((chain) => chain.family === 'evm').length;
   const legacyCount = chains.filter((chain) => chain.legacyHarmonyAdapter).length;
   const pluginTypes = new Set(chains.flatMap((chain) => chain.capabilities?.supportedPluginTypes ?? []));
+  const governanceStatusCounts = chains.reduce((acc, chain) => {
+    const status = chain.governanceStatus ?? 'under-review';
+    acc[status] = (acc[status] ?? 0) + 1;
+    return acc;
+  }, {});
+  const federationTierCounts = chains.reduce((acc, chain) => {
+    const tier = chain.federationTier ?? 'observer';
+    acc[tier] = (acc[tier] ?? 0) + 1;
+    return acc;
+  }, {});
+  const reasonSeverityCounts = chains.reduce((acc, chain) => {
+    const severity = chain.indexingStatus?.reasonSeverity ?? chain.constitutionalStanding?.reasonSeverity;
+    if (!severity) return acc;
+    acc[severity] = (acc[severity] ?? 0) + 1;
+    return acc;
+  }, {});
 
   return {
     totalChains: chains.length,
@@ -451,5 +459,8 @@ export function summarizeChainRegistry(chains) {
     legacyCount,
     pluginTypes: pluginTypes.size,
     roleCounts,
+    governanceStatusCounts,
+    federationTierCounts,
+    reasonSeverityCounts,
   };
 }

--- a/src/modules/governance/hooks/useGovernanceConsole.js
+++ b/src/modules/governance/hooks/useGovernanceConsole.js
@@ -1,9 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { fetchGovernanceDaos, fetchGovernancePlugins, fetchGovernanceProposals, getFederalDaoRecord } from '../api/governanceClient';
 import { useWallet } from '@/hooks/useWallet';
+import { getConstitutionalStanding } from '../utils/governanceState';
 
 function normalizeDao(dao) {
-  const constitutionalStanding = dao.constitutionalStanding ?? dao.constitutionalCompliance ?? { status: 'under-review', reasonCodes: [], reasonSeverity: null };
+  const hasStanding = dao.constitutionalStanding || dao.constitutionalCompliance || dao.constitutionalCompatibility;
+  const constitutionalStanding = hasStanding
+    ? getConstitutionalStanding(dao)
+    : { status: 'under-review', reasonCodes: [], reasonSeverity: null };
 
   return {
     ...dao,

--- a/src/modules/governance/pages/GovernanceDashboard.jsx
+++ b/src/modules/governance/pages/GovernanceDashboard.jsx
@@ -117,6 +117,63 @@ function OperationsPanel() {
   );
 }
 
+function ObservabilityPanel({ summary }) {
+  const statusEntries = Object.entries(summary.governanceStatusCounts ?? {});
+  const tierEntries = Object.entries(summary.federationTierCounts ?? {});
+  const severityEntries = Object.entries(summary.reasonSeverityCounts ?? {});
+
+  return (
+    <section className="rounded-lg border border-white/5 bg-surface-container-highest p-5">
+      <div className="mb-5 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-bold text-on-surface">Governance Observability</h2>
+          <p className="mt-1 text-xs text-on-surface-variant">Registry-rendered status, federation tier and guardrail severity distribution.</p>
+        </div>
+        <span className="material-symbols-outlined text-cyan-200">monitoring</span>
+      </div>
+      <div className="grid gap-3 md:grid-cols-3">
+        <div className="rounded-md bg-surface-container-high p-3">
+          <div className="text-xs font-bold uppercase text-slate-500">Governance status</div>
+          <div className="mt-3 space-y-2">
+            {statusEntries.map(([status, count]) => (
+              <div key={status} className="flex items-center justify-between text-xs text-on-surface-variant">
+                <span>{status}</span>
+                <span className="font-black text-on-surface">{count}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="rounded-md bg-surface-container-high p-3">
+          <div className="text-xs font-bold uppercase text-slate-500">Federation tiers</div>
+          <div className="mt-3 space-y-2">
+            {tierEntries.map(([tier, count]) => (
+              <div key={tier} className="flex items-center justify-between text-xs text-on-surface-variant">
+                <span>{tier}</span>
+                <span className="font-black text-on-surface">{count}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="rounded-md bg-surface-container-high p-3">
+          <div className="text-xs font-bold uppercase text-slate-500">Guardrail severity</div>
+          <div className="mt-3 space-y-2">
+            {severityEntries.length > 0 ? (
+              severityEntries.map(([severity, count]) => (
+                <div key={severity} className="flex items-center justify-between text-xs text-on-surface-variant">
+                  <span>{severity}</span>
+                  <span className="font-black text-on-surface">{count}</span>
+                </div>
+              ))
+            ) : (
+              <div className="text-xs text-on-surface-variant">No active severity metadata</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 export default function GovernanceDashboard() {
   const { chains, summary, source, status, error } = useChainRegistry();
   const governanceConsole = useGovernanceConsole(chains);
@@ -156,6 +213,8 @@ export default function GovernanceDashboard() {
           <ExecutionChainPanel chain={executionChain} />
           <OperationsPanel />
         </section>
+
+        <ObservabilityPanel summary={summary} />
 
         <section className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           <GovernanceLayerCard

--- a/src/modules/governance/pages/GovernanceLanding.jsx
+++ b/src/modules/governance/pages/GovernanceLanding.jsx
@@ -119,7 +119,7 @@ export default function GovernanceLanding() {
           <PublicMetric label="Supported chains" value={publicRegistryChains.length} detail={`${summary.evmCount} EVM core networks`} />
           <PublicMetric label="Voting surfaces" value={publicRoleCounts.voting} detail="Cross-chain participation readiness" />
           <PublicMetric label="Spoke networks" value={publicRoleCounts.spoke} detail="Operational execution targets" />
-          <PublicMetric label="Plugin types" value={summary.pluginTypes} detail="Governance capabilities exposed by registry" />
+          <PublicMetric label="Compliant status" value={summary.governanceStatusCounts?.compliant ?? 0} detail="Registry-rendered governance status" />
         </section>
 
         <section className="grid grid-cols-1 gap-4 md:grid-cols-3">

--- a/src/modules/governance/transactions/governanceActionGuards.js
+++ b/src/modules/governance/transactions/governanceActionGuards.js
@@ -1,14 +1,4 @@
-function severityForReason(reasonCode, status) {
-  if (!reasonCode) return null;
-  if (reasonCode === 'TREASURY_POLICY_REQUIRES_REVIEW' || reasonCode === 'AGENT_PERMISSION_SCOPE_EXCEEDED') return 'constitutional';
-  if (status === 'blocked') return 'critical';
-  if (status === 'warning') return 'warning';
-  return 'info';
-}
-
-function getConstitutionalStanding(target) {
-  return target?.constitutionalStanding ?? target?.constitutionalCompatibility;
-}
+import { getConstitutionalStanding, severityForReason } from '../utils/governanceState';
 
 function checkResult(label, status, message, reasonCode = null, source = null, reasonSeverity = null) {
   return { label, status, message, reasonCode, source, reasonSeverity: reasonSeverity ?? severityForReason(reasonCode, status) };

--- a/src/modules/governance/utils/governanceState.js
+++ b/src/modules/governance/utils/governanceState.js
@@ -1,0 +1,37 @@
+export const COMPLIANT_CONSTITUTIONAL_STANDING = {
+  status: 'compliant',
+  reasonCodes: [],
+  reasonSeverity: null,
+};
+
+export function mapCompatibilityToStanding(value) {
+  if (!value) return COMPLIANT_CONSTITUTIONAL_STANDING;
+  if (value.status === 'compatible') return { ...value, status: 'compliant', reasonSeverity: value.reasonSeverity ?? null };
+  if (value.status === 'requires-review') return { ...value, status: 'under-review', reasonSeverity: value.reasonSeverity ?? 'constitutional' };
+  if (value.status === 'incompatible') return { ...value, status: 'restricted', reasonSeverity: value.reasonSeverity ?? 'critical' };
+  return { ...value, reasonSeverity: value.reasonSeverity ?? null };
+}
+
+export function getConstitutionalStanding(target) {
+  return mapCompatibilityToStanding(target?.constitutionalStanding ?? target?.constitutionalCompliance ?? target?.constitutionalCompatibility);
+}
+
+export function governanceStatusFromStanding(standing) {
+  if (standing?.status === 'under-review') return 'under-review';
+  if (standing?.status === 'restricted') return 'restricted';
+  if (standing?.status === 'sanctioned') return 'sanctioned';
+  if (standing?.status === 'suspended') return 'suspended';
+  return 'compliant';
+}
+
+export function severityForReason(reasonCode, status) {
+  if (!reasonCode) return null;
+  if (reasonCode === 'TREASURY_POLICY_REQUIRES_REVIEW' || reasonCode === 'AGENT_PERMISSION_SCOPE_EXCEEDED') return 'constitutional';
+  if (status === 'blocked') return 'critical';
+  if (status === 'warning') return 'warning';
+  return 'info';
+}
+
+export function normalizeReasonSeverity(reasonCode, reasonSeverity, fallbackStatus = 'warning') {
+  return reasonSeverity ?? severityForReason(reasonCode, fallbackStatus);
+}


### PR DESCRIPTION
Introduce a centralized governanceState utility (standing mapping, severity normalization, governance status helpers) and replace duplicated logic across the codebase. Refactor chainRegistry, governanceActionGuards, and useGovernanceConsole to use the new helpers, normalize reasonSeverity handling, and switch to a shared COMPLIANT_CONSTITUTIONAL_STANDING. Extend registry summaries with governanceStatusCounts, federationTierCounts, and reasonSeverityCounts. Add an ObservabilityPanel to GovernanceDashboard to surface these metrics and update GovernanceLanding to show compliant status. Also update TASKS.md to reflect new governance standing/console notes.